### PR TITLE
Add 'Hot it works' wiki page and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For detailed documentation, please visit the [Wiki](wiki/):
 - **[Configuration Guide](wiki/Configuration-Guide.md)** - Complete configuration reference with examples
 - **[Color Reference](wiki/Color-Reference.md)** - All 16 available colors
 - **[Wildcard Patterns](wiki/Wildcard-Patterns.md)** - Pattern matching guide
+- **[Hot it works](wiki/Hot-it-works.md)** - How EnvTabs uses SSMS color tabs and salt-based hashing
 - **[Troubleshooting](wiki/Troubleshooting.md)** - Common issues and solutions
 - **[Tips & Best Practices](wiki/Tips-and-Best-Practices.md)** - Optimize your workflow
 

--- a/wiki/Hot-it-works.md
+++ b/wiki/Hot-it-works.md
@@ -1,0 +1,38 @@
+# Hot it works
+
+This page explains how SSMS EnvTabs reuses SSMS's built-in **Color Tabs by Regex** mechanism, and how it uses a **salt** to hit the color you request in your rules.
+
+## 1) EnvTabs generates regex rules for SSMS
+
+EnvTabs does **not** paint tabs directly. Instead, it writes regex rules into the same `ColorByRegexConfig.txt` file that SSMS already uses for Color Tabs by Regex. The extension builds a generated block (between `BEGIN`/`END` markers) containing regex lines that map the open documents in each EnvTabs group to the SSMS Color Tabs system.【F:SSMS EnvTabs/ColorByRegexConfigWriter.cs†L11-L17】【F:SSMS EnvTabs/ColorByRegexConfigWriter.cs†L86-L110】
+
+To keep colors stable even when files move between folders, the regex is built from **file names only**. Each group gets a regex that matches any path ending in one of those filenames:
+
+```
+(?:^|[\\/])(?:FileA.sql|FileB.sql)$
+```
+
+This comes directly from EnvTabs escaping the filenames and assembling a regex that matches any path ending with one of them.【F:SSMS EnvTabs/ColorByRegexConfigWriter.cs†L72-L83】【F:SSMS EnvTabs/ColorByRegexConfigWriter.cs†L117-L123】
+
+## 2) SSMS picks a color by hashing the regex
+
+SSMS chooses a color index by hashing the full regex line and taking `abs(hash) % 16`. EnvTabs mirrors that behavior via a legacy, stable string hash so it can predict the exact color SSMS will choose.【F:SSMS EnvTabs/ColorByRegexConfigWriter.cs†L125-L143】【F:SSMS EnvTabs/TabGroupColorSolver.cs†L27-L35】【F:SSMS EnvTabs/TabGroupColorSolver.cs†L45-L67】
+
+## 3) The salt nudges the hash without changing the match
+
+If your EnvTabs rule specifies a target `ColorIndex`, EnvTabs appends a **regex comment** to the end of the generated regex:
+
+```
+(?#salt:123)
+```
+
+Because this is a regex comment, it **does not affect matching**, but it **does change the hash input**. EnvTabs brute-forces a numeric salt until the hash result matches your requested color index, then appends it to the regex.【F:SSMS EnvTabs/ColorByRegexConfigWriter.cs†L125-L150】【F:SSMS EnvTabs/TabGroupColorSolver.cs†L10-L39】
+
+## 4) Putting it together
+
+1. EnvTabs groups tabs by your server/database rule.
+2. It writes regex lines into `ColorByRegexConfig.txt` for SSMS to consume.
+3. If a color is specified, EnvTabs finds a salt so SSMS’s hash lands on that color.
+4. SSMS applies the matching color using its built-in Color Tabs by Regex system.
+
+That’s how EnvTabs piggybacks on SSMS’s existing coloring feature while still giving you deterministic, rule-based colors.


### PR DESCRIPTION
### Motivation
- Provide a concise, developer-focused explanation of how the extension leverages SSMS's built-in Color Tabs by Regex and how a regex comment "salt" is used to force a desired color index so rules produce deterministic colors.

### Description
- Add `wiki/Hot-it-works.md` explaining that EnvTabs writes regex lines into SSMS's `ColorByRegexConfig.txt`, builds regexes from filenames, computes SSMS-style hashes, and brute-forces a `(?#salt:...)` comment to reach a target `ColorIndex` (references `ColorByRegexConfigWriter.cs` and `TabGroupColorSolver.cs`).
- Update `README.md` to include a link to the new `Hot it works` wiki page in the documentation list.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f7dad35483228793ecf37bbe4635)