### PR TITLE
Fix color updates when auto-rename is disabled

### DIFF
--- a/SSMS EnvTabs/RdtEventManager.cs
+++ b/SSMS EnvTabs/RdtEventManager.cs
@@ -278,11 +278,15 @@ namespace SSMS_EnvTabs
                 }
             }
 
-            bool shouldUpdateColor = renamedCount > 0 
-                || (reason != null && (
-                    reason.IndexOf("DocumentWindowShow", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    reason.IndexOf("AttributeChange", StringComparison.OrdinalIgnoreCase) >= 0
-                   ));
+            bool isConnectionEvent = reason != null && (
+                reason.IndexOf("DocumentWindowShow", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                reason.IndexOf("AttributeChange", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                reason.IndexOf("AttributeChangeEx", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                reason.IndexOf("ActiveFrameChanged", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                reason.IndexOf("DocViewEvent", StringComparison.OrdinalIgnoreCase) >= 0
+            );
+
+            bool shouldUpdateColor = renamedCount > 0 || isConnectionEvent;
 
             if (config.Settings?.EnableAutoColor == true && shouldUpdateColor)
             {


### PR DESCRIPTION
### Motivation
- Fix a bug where `enableAutoRename: false` combined with `enableAutoColor: true` prevented color-by-regex updates after connection-related events, so colors were not applied to new tabs.

### Description
- Update `SSMS EnvTabs/RdtEventManager.cs` to compute an `isConnectionEvent` flag for a broader set of event reasons and use it to decide color updates instead of relying on renames. 
- The new check includes `DocumentWindowShow`, `AttributeChange`, `AttributeChangeEx`, `ActiveFrameChanged`, and `DocViewEvent` so color refreshes run even when renaming is disabled. 
- Replace the previous inline `shouldUpdateColor` expression with `isConnectionEvent` plus `renamedCount > 0` logic to ensure color updates are triggered appropriately. 

### Testing
- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977be444fc083228665f206a4cbc2d8)