### PR TITLE
Skip color updates until connection resolves; avoid rewriting regex config on newline-only changes

### DIFF
--- a/SSMS EnvTabs/ColorByRegexConfigWriter.cs
+++ b/SSMS EnvTabs/ColorByRegexConfigWriter.cs
@@ -207,7 +207,7 @@ namespace SSMS_EnvTabs
         private static void WriteIfChanged(string path, string content)
         {
             string existing = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
-            if (string.Equals(existing, content ?? string.Empty, StringComparison.Ordinal))
+            if (string.Equals(NormalizeNewlines(existing), NormalizeNewlines(content ?? string.Empty), StringComparison.Ordinal))
             {
                 return;
             }
@@ -229,6 +229,16 @@ namespace SSMS_EnvTabs
             {
                 File.Move(tmp, path);
             }
+        }
+
+        private static string NormalizeNewlines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+
+            return text.Replace("\r\n", "\n").Replace("\r", "\n");
         }
 
         private string ResolveConfigPath(IEnumerable<string> monikers)

--- a/SSMS EnvTabs/RdtEventManager.cs
+++ b/SSMS EnvTabs/RdtEventManager.cs
@@ -286,7 +286,7 @@ namespace SSMS_EnvTabs
                 reason.IndexOf("DocViewEvent", StringComparison.OrdinalIgnoreCase) >= 0
             );
 
-            bool shouldUpdateColor = renamedCount > 0 || isConnectionEvent;
+            bool shouldUpdateColor = !needsRetry && (renamedCount > 0 || isConnectionEvent);
 
             if (config.Settings?.EnableAutoColor == true && shouldUpdateColor)
             {


### PR DESCRIPTION
### Motivation
- Prevent transient removal of tab colors by skipping color updates while connection details are still pending so UI prompts/cancels don't clear colors. 
- Avoid unnecessary updates to the generated regex file that only change timestamps (and trigger SSMS reloads) when the file contents differ only by line endings. 

### Description
- Require `!needsRetry` when deciding `shouldUpdateColor` in `RdtEventManager.cs` so color updates are skipped until connection info has resolved. 
- Change `WriteIfChanged` in `ColorByRegexConfigWriter.cs` to compare normalized newlines instead of raw text so files with only line-ending differences are not rewritten. 
- Add a `NormalizeNewlines` helper and reuse existing line-splitting normalization to ensure consistent newline handling when comparing and assembling file contents. 
- Preserve atomic write behavior by still writing to a `.tmp` file and using `File.Replace`/`File.Move` when a real change is detected. 

### Testing
- No automated tests were run for these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c9599f5c832284752514e9613c44)